### PR TITLE
Add Support for Batch Conversion via Directory Input

### DIFF
--- a/packages/markitdown/src/openize/markitdown/core.py
+++ b/packages/markitdown/src/openize/markitdown/core.py
@@ -1,3 +1,5 @@
+import os
+
 from processor import DocumentProcessor
 
 
@@ -9,3 +11,10 @@ class MarkItDown:
         """Run the document conversion process."""
         processor = DocumentProcessor(self.output_dir)
         processor.process_document(input_file, insert_into_llm)
+
+    def convert_directory(self, input_dir: str, insert_into_llm: bool = False):
+        supported_exts = [".docx", ".pdf", ".xlsx", ".pptx"]
+        for filename in os.listdir(input_dir):
+            filepath = os.path.join(input_dir, filename)
+            if os.path.isfile(filepath) and os.path.splitext(filename)[1].lower() in supported_exts:
+                self.convert_document(filepath, insert_into_llm)

--- a/packages/markitdown/src/openize/markitdown/main.py
+++ b/packages/markitdown/src/openize/markitdown/main.py
@@ -48,8 +48,10 @@ def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
     parser = argparse.ArgumentParser(description="Convert documents to Markdown.")
-    parser.add_argument("input_file", help="Path to the input document (PDF, Word, etc.)")
-    parser.add_argument("-o", "--output-dir", required=True, help="Directory to save the converted Markdown file")
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--input-file", help="Path to the input document (PDF, Word, etc.)")
+    input_group.add_argument("--input-dir", help="Path to a directory containing supported documents")
+    parser.add_argument("-o", "--output-dir", required=True, help="Directory to save the converted Markdown file(s)")
     parser.add_argument("--insert-into-llm", action="store_true", help="Insert output into LLM")
 
     args = parser.parse_args()
@@ -66,14 +68,15 @@ def main():
             ensure_env_variable("OPENAI_API_KEY", "Enter your OpenAI API key: ")
             ensure_env_variable("OPENAI_MODEL", "Enter OpenAI model name (default: gpt-4): ", default="gpt-4")
 
-        # Run conversion
+        # Run conversion for either a single file or a directory
         markitdown = MarkItDown(args.output_dir)
-        markitdown.convert_document(args.input_file, args.insert_into_llm)
+
+        if args.input_file:
+            markitdown.convert_document(args.input_file, args.insert_into_llm)
+        elif args.input_dir:
+            markitdown.convert_directory(args.input_dir, args.insert_into_llm)
 
     except Exception as e:
         logging.error(f"Error: {e}", exc_info=True)
         sys.exit(1)
 
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## New Features
- Directory input support: Pass --input-dir to convert all supported files (.docx, .pdf, .pptx, .xlsx) in a folder.
- Still supports single file input with --input-file.
- --output-dir is now mandatory to ensure output files are saved consistently.
- --insert-into-llm still works in both modes (optional).
- Automatic creation of output directory if it doesn’t exist.

### Example: CLI Usage
```
markitdown --input-dir ./documents --output-dir ./markdowns
```
### Example: Convert an Entire Folder via API

```
from markitdown import MarkItDown

converter = MarkItDown(output_dir="./markdowns")
converter.convert_directory(input_dir="./documents", insert_into_llm=True)
```